### PR TITLE
fix: https team logos (#19)

### DIFF
--- a/lib/reshape-teams-from-cfbd.ts
+++ b/lib/reshape-teams-from-cfbd.ts
@@ -8,7 +8,7 @@ export const extractTeamsFromCfbd = (cfbdTeams: Team[], conferenceId: string): R
     displayName: team.school + (team.mascot ? ` ${team.mascot}` : ''),
     shortDisplayName: team.school,
     abbreviation: team.abbreviation ?? '',
-    logo: team.logos?.[0] || '',
+    logo: (team.logos?.[0] || '').replace(/^http:\/\//, 'https://'),
     color: team.color || '000000',
     alternateColor: team.alternateColor || '000000',
     conference: team.conference || conferenceId,


### PR DESCRIPTION
Closes #19.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only normalizes team logo URLs by upgrading `http://` to `https://`, with no impact on data shape or business logic beyond the logo field.
> 
> **Overview**
> Ensures team `logo` URLs produced by `extractTeamsFromCfbd` are always HTTPS by rewriting a leading `http://` to `https://` when mapping CFBD teams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6681d03833c6098b278caa6a0c1b8211f1abf228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->