### PR TITLE
fix(nav): close dropdown after selecting a conference (issue #17)

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -48,7 +48,7 @@ const Navigation = () => {
                   handleConferenceSelect(key);
                 }}
                 className={cn(
-                  'flex items-center gap-2 rounded-md py-2 pl-[calc(0.75rem+1rem+0.5rem)] pr-3 font-semibold uppercase',
+                  'dropdown-close flex items-center gap-2 rounded-md py-2 pl-[calc(0.75rem+1rem+0.5rem)] pr-3 font-semibold uppercase',
                   key === currentConf && 'bg-base-200 text-primary dark:text-accent'
                 )}
               >


### PR DESCRIPTION
## Summary
- After client-side navigation the clicked `<a>` keeps focus, so DaisyUI's `:focus-within` rule on `dropdown-hover` keeps the panel open.
- Adding `dropdown-close` to the menu items blurs the active element on click, allowing the panel to close on select.

## Test plan
- [ ] Desktop: hover trigger → menu opens; pick a conference → menu closes and route changes.
- [ ] Desktop keyboard: Tab to trigger → menu opens; Enter on item → menu closes.
- [ ] Mobile (iOS Safari): tap trigger → menu opens; tap a conference → menu closes and route changes.

Closes #17

Made with [Cursor](https://cursor.com)